### PR TITLE
fix systemd unit start flag

### DIFF
--- a/packaging/usr/lib/systemd/system/access-log-exporter.service
+++ b/packaging/usr/lib/systemd/system/access-log-exporter.service
@@ -11,7 +11,7 @@ User=access-log-exporter-dynamic
 Group=access-log-exporter-dynamic
 SupplementaryGroups=access-log-exporter
 
-ExecStart=/usr/bin/access-log-exporter -config-file ${CONFIG_FILE}
+ExecStart=/usr/bin/access-log-exporter -config ${CONFIG_FILE}
 NoExecPaths=/
 ExecPaths=/usr/bin/access-log-exporter /usr/bin/env /usr/bin/kill
 ExecReload=/usr/bin/env kill -USR1 $MAINPID


### PR DESCRIPTION
#### What this PR does / why we need it

systemd unit failed to start, updated flag to resolve
```
Dec 16 19:34:01 sentinowl-vm1 access-log-exporter[132806]: flag provided but not defined: -config-file
...
Dec 16 19:34:01 sentinowl-vm1 access-log-exporter[132806]: configuration error: error parsing command line arguments: flag provided but not defined: -config-file
Dec 16 19:34:01 sentinowl-vm1 systemd[1]: access-log-exporter.service: Main process exited, code=exited, status=1/FAILURE
Dec 16 19:34:01 sentinowl-vm1 systemd[1]: access-log-exporter.service: Failed with result 'exit-code'.
```

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

- fixes #

#### Special notes for your reviewer

#### Particularly user-facing changes

#### Checklist

Complete these before marking the PR as `ready to review`:

<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->

- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] The PR title has a summary of the changes
- [x] The PR body has a summary to reflect any significant (and particularly user-facing) changes introduced by this PR
